### PR TITLE
Get home directory in platform-independent way

### DIFF
--- a/pydl/pydlspec2d/spec1d/template_input.py
+++ b/pydl/pydlspec2d/spec1d/template_input.py
@@ -496,6 +496,9 @@ def template_input_main():  # pragma: no cover
     import os
     import sys
     from astropy.utils.compat import argparse
+
+    # Get home directory in platform-independent way
+    home_dir = os.path.expanduser('~')
     #
     # Get Options
     #
@@ -503,13 +506,13 @@ def template_input_main():  # pragma: no cover
                                      prog=os.path.basename(sys.argv[0]))
     parser.add_argument('-d', '--dump', action='store', dest='dump',
                         metavar='FILE',
-                        default=os.path.join(os.getenv('HOME'), 'scratch', 'templates', 'compute_templates.dump'),
+                        default=os.path.join(home_dir, 'scratch', 'templates', 'compute_templates.dump'),
                         help='Dump data to a pickle file.')
     parser.add_argument('-F', '--flux', action='store_true', dest='flux',
                         help='Plot input spectra.')
     parser.add_argument('-f', '--file', action='store', dest='inputfile',
                         metavar='FILE',
-                        default=os.path.join(os.getenv('HOME'), 'scratch', 'templates', 'compute_templates.par'),
+                        default=os.path.join(home_dir, 'scratch', 'templates', 'compute_templates.par'),
                         help='Read input spectra and redshifts from FILE.')
     parser.add_argument('-v', '--verbose', action='store_true', dest='verbose',
                         help='Print lots of extra information.')


### PR DESCRIPTION
In the process of building a conda package for the latest pydl release in astropy/conda-builder-affiliated#84 @bsipocz and found that one of the scripts fails on Windows. Turns out the issue is that the environment variable `$HOME` is not typically set on Windows, and the script used it to set a default value for a couple of arguments.

This PR fixes that. For the conda package for 0.4.1 we'll just skip the test of that script (`pca_gal`) -- in the future if you'd prefer that we not build it at all for Windows, let me know.