### PR TITLE
Fix test failures on 32-bit systems.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
 
 env:
     global:
+
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
@@ -30,11 +31,19 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
+
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        # - CONDA_DEPENDENCIES='libgfortran=1.0 scipy matplotlib'
+        # - CONDA_DEPENDENCIES='Cython'
         - CONDA_DEPENDENCIES='scipy matplotlib'
+
+        # Conda packages for affiliated packages are hosted in channel
+        # "astropy" while builds for astropy LTS with recent numpy versions
+        # are in astropy-ci-extras. If your package uses either of these,
+        # add the channels to CONDA_CHANNELS along with any other channels
+        # you want to use.
+        - CONDA_CHANNELS='astopy-ci-extras astropy'
 
         # If there are matplotlib or other GUI tests, uncomment the following
         # line to use the X virtual framebuffer.
@@ -68,14 +77,11 @@ matrix:
         - python: 3.5
           env: ASTROPY_VERSION=lts
 
-        # Python 2.6 and 3.3 doesn't have numpy 1.10 in conda, they can be put
+        # Python 3.3 doesn't have numpy 1.10 in conda, but can be put
         # back into the main matrix once the numpy build is available in the
         # astropy-ci-extras channel (or in the one provided in the
         # CONDA_CHANNELS environmental variable).
-        # - python: 2.6
-        #   env: SETUP_CMD='egg_info'
-        # - python: 2.6
-        #   env: SETUP_CMD='test' NUMPY_VERSION=1.9
+
         - python: 3.3
           env: SETUP_CMD='egg_info'
         - python: 3.3
@@ -104,7 +110,7 @@ install:
     # We now use the ci-helpers package to set up our testing environment.
     # This is done by using Miniconda and then using conda and pip to install
     # dependencies. Which dependencies are installed using conda and pip is
-    # determined by the CONDA_DEPDENDENCIES and PIP_DEPENDENCIES variables,
+    # determined by the CONDA_DEPENDENCIES and PIP_DEPENDENCIES variables,
     # which should be space-delimited lists of package names. See the README
     # in https://github.com/astropy/ci-helpers for information about the full
     # list of environment variables that can be used to customize your

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ env:
         # are in astropy-ci-extras. If your package uses either of these,
         # add the channels to CONDA_CHANNELS along with any other channels
         # you want to use.
-        - CONDA_CHANNELS='astopy-ci-extras astropy'
+        # - CONDA_CHANNELS='astopy-ci-extras astropy'
+        - CONDA_CHANNELS='astropy'
 
         # If there are matplotlib or other GUI tests, uncomment the following
         # line to use the X virtual framebuffer.

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,9 +74,9 @@ matrix:
         - python: 3.5
           env: ASTROPY_VERSION=development
         - python: 2.7
-          env: ASTROPY_VERSION=lts
+          env: ASTROPY_VERSION=lts NUMPY_VERSION=1.10
         - python: 3.5
-          env: ASTROPY_VERSION=lts
+          env: ASTROPY_VERSION=lts NUMPY_VERSION=1.10
 
         # Python 3.3 doesn't have numpy 1.10 in conda, but can be put
         # back into the main matrix once the numpy build is available in the

--- a/docs/pydl/changes.rst
+++ b/docs/pydl/changes.rst
@@ -6,6 +6,9 @@ PyDL Changelog
 ------------------
 
 * Fixed formatting of TODO document.
+* Fixed tests that were failing on 32-bit platforms (`Issue #14`).
+
+.. _`Issue #14`: https://github.com/weaverba137/pydl/issues/14
 
 0.5.2 (2016-08-04)
 ------------------

--- a/pydl/pydlutils/misc.py
+++ b/pydl/pydlutils/misc.py
@@ -56,11 +56,11 @@ def djs_laxisgen(dims, iaxis=0):
     Examples
     --------
     >>> from pydl.pydlutils.misc import djs_laxisgen
-    >>> djs_laxisgen([4,4])
-    array([[0, 0, 0, 0],
-           [1, 1, 1, 1],
-           [2, 2, 2, 2],
-           [3, 3, 3, 3]], dtype=int32)
+    >>> print(djs_laxisgen([4,4]))
+    [[0 0 0 0]
+     [1 1 1 1]
+     [2 2 2 2]
+     [3 3 3 3]]
     """
     ndimen = len(dims)
     if ndimen == 1:
@@ -98,11 +98,11 @@ def djs_laxisnum(dims, iaxis=0):
     Examples
     --------
     >>> from pydl.pydlutils.misc import djs_laxisnum
-    >>> djs_laxisnum([4,4])
-    array([[0, 0, 0, 0],
-           [1, 1, 1, 1],
-           [2, 2, 2, 2],
-           [3, 3, 3, 3]], dtype=int32)
+    >>> print(djs_laxisnum([4,4]))
+    [[0 0 0 0]
+     [1 1 1 1]
+     [2 2 2 2]
+     [3 3 3 3]]
     """
     ndimen = len(dims)
     result = np.zeros(dims, dtype='i4')

--- a/pydl/pydlutils/sdss.py
+++ b/pydl/pydlutils/sdss.py
@@ -327,7 +327,9 @@ def sdss_objid(run, camcol, field, objnum, rerun=301, skyversion=None):
 
     Notes
     -----
-    firstField flag never set.
+    * ``firstField`` flag never set.
+    * On 32-bit systems, makes sure to explicitly declare all inputs as
+      64-bit integers.
 
     Examples
     --------

--- a/pydl/pydlutils/sdss.py
+++ b/pydl/pydlutils/sdss.py
@@ -334,8 +334,8 @@ def sdss_objid(run, camcol, field, objnum, rerun=301, skyversion=None):
     Examples
     --------
     >>> from pydl.pydlutils.sdss import sdss_objid
-    >>> sdss_objid(3704,3,91,146)
-    array([1237661382772195474])
+    >>> print(sdss_objid(3704,3,91,146))
+    [1237661382772195474]
     """
     if skyversion is None:
         skyversion = default_skyversion()

--- a/pydl/pydlutils/tests/test_sdss.py
+++ b/pydl/pydlutils/tests/test_sdss.py
@@ -129,7 +129,8 @@ class TestSDSS(object):
         camcol = np.array([3, 6])
         field = np.array([91, 77])
         obj = np.array([146, 123])
-        assert (np.array([1237661382772195474, 1237649770790322299]) ==
+        assert (np.array([1237661382772195474, 1237649770790322299],
+                         dtype=np.int64) ==
                 sdss_objid(run, camcol, field, obj)).all()
         #
         # Exceptions

--- a/pydl/pydlutils/tests/test_sdss.py
+++ b/pydl/pydlutils/tests/test_sdss.py
@@ -125,10 +125,10 @@ class TestSDSS(object):
 
     def test_sdss_objid(self):
         assert sdss_objid(3704, 3, 91, 146) == 1237661382772195474
-        run = np.array([3704, 1000])
-        camcol = np.array([3, 6])
-        field = np.array([91, 77])
-        obj = np.array([146, 123])
+        run = np.array([3704, 1000], dtype=np.int64)
+        camcol = np.array([3, 6], dtype=np.int64)
+        field = np.array([91, 77], dtype=np.int64)
+        obj = np.array([146, 123], dtype=np.int64)
         assert (np.array([1237661382772195474, 1237649770790322299],
                          dtype=np.int64) ==
                 sdss_objid(run, camcol, field, obj)).all()

--- a/pydl/pydlutils/tests/test_yanny.py
+++ b/pydl/pydlutils/tests/test_yanny.py
@@ -122,7 +122,8 @@ class TestYanny(YannyTestCase):
         b = [2.0, 5.0, 8.2]
         c = [b'x', b'y', b'z']
         t = Table([a, b, c], names=('a', 'b', 'c'),
-                  meta={'name': 'first table'})
+                  meta={'name': 'first table'},
+                  dtype=('i8', 'f8', 'S1'))
         t.write(filename, tablename='test')
         par1 = yanny(filename)
         par2 = yanny(self.data('test_table.par'))


### PR DESCRIPTION
This PR fixes #14 by reformatting or refactoring some test that were broken  on 32-bit systems.  In some cases, this involved wrapping the outputs in a `print()` function.  In other cases it involved being more explicit about the types of input data.