### PR TITLE
Use the generic ci-helpers script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ install:
     # commands in the install: section below.
 
     - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - source ci-helpers/travis/setup_conda.sh
 
     # As described above, using ci-helpers, you should be able to set up an
     # environment with dependencies installed using conda and pip, but in some


### PR DESCRIPTION
Using the generic script will allow us to put more generic stuff in there without code repetition, e.g. the checks for the custom tags and skipping the builds early.