### PR TITLE
Firstfield fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,9 +82,6 @@ matrix:
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
         - os: linux
-          env: ASTROPY_VERSION=development
-               EVENT_TYPE='pull_request push cron'
-        - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts
         - os: linux
           env: ASTROPY_VERSION=lts

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,9 +77,9 @@ matrix:
         - os: linux
           env: SETUP_CMD='build_docs -w'
 
-        # Now try Astropy dev and LTS vesions with the latest 3.x and 2.7.
+        # Now try Astropy dev with the latest Python and LTS with Python 2.7 and 3.x.
         - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development
+          env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
         - os: linux
           env: ASTROPY_VERSION=development
@@ -100,6 +100,8 @@ matrix:
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.10
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
+        - os: linux
+          env: NUMPY_VERSION=1.12
 
         # Try numpy pre-release
         - os: linux
@@ -129,7 +131,7 @@ install:
     # in how to install a package, in which case you can have additional
     # commands in the install: section below.
 
-    - git clone git://github.com/astropy/ci-helpers.git
+    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
 
     # As described above, using ci-helpers, you should be able to set up an

--- a/docs/pydl/changes.rst
+++ b/docs/pydl/changes.rst
@@ -5,7 +5,9 @@ PyDL Changelog
 0.6.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Support the ``firstField`` bit in ObjIDs from DR7 and earlier (Issue `#37`_).
+
+.. _`#37`: https://github.com/weaverba137/pydl/issues/37.
 
 0.6.0 (2017-09-19)
 ------------------

--- a/pydl/__init__.py
+++ b/pydl/__init__.py
@@ -30,9 +30,9 @@ if not _ASTROPY_SETUP_:
 
 
 # Workaround: Numpy 1.14.x changes the way arrays are printed.
-import numpy as np
 try:
-    np.set_printoptions(legacy='1.13')
+    from numpy import set_printoptions
+    set_printoptions(legacy='1.13')
 except Exception:
     pass
 

--- a/pydl/__init__.py
+++ b/pydl/__init__.py
@@ -29,6 +29,14 @@ if not _ASTROPY_SETUP_:
     from .uniq import uniq
 
 
+# Workaround: Numpy 1.14.x changes the way arrays are printed.
+import numpy as np
+try:
+    np.set_printoptions(legacy='1.13')
+except Exception:
+    pass
+
+
 class PydlException(Exception):
     """Base class for exceptions raised in PyDL functions.
     """

--- a/pydl/photoop/photoobj.py
+++ b/pydl/photoop/photoobj.py
@@ -40,8 +40,8 @@ def unwrap_objid(objid):
     Returns
     -------
     :class:`numpy.recarray`
-        A record array with the same length as objid, with the columns
-        'run', 'camcol', 'frame', 'id', 'rerun', 'skyversion'.
+        A record array with the same length as `objid`, with the columns
+        'skyversion', 'rerun', 'run', 'camcol', 'firstfield', 'frame', 'id'.
 
     Notes
     -----
@@ -57,8 +57,8 @@ def unwrap_objid(objid):
     >>> from numpy import array
     >>> from pydl.photoop.photoobj import unwrap_objid
     >>> unwrap_objid(array([1237661382772195474]))
-    rec.array([(2, 301, 3704, 3, 91, 146)],
-          dtype=[('skyversion', '<i4'), ('rerun', '<i4'), ('run', '<i4'), ('camcol', '<i4'), ('frame', '<i4'), ('id', '<i4')])
+    rec.array([(2, 301, 3704, 3, 0, 91, 146)],
+          dtype=[('skyversion', '<i4'), ('rerun', '<i4'), ('run', '<i4'), ('camcol', '<i4'), ('firstfield', '<i4'), ('frame', '<i4'), ('id', '<i4')])
     """
     import numpy as np
     if objid.dtype.type is np.string_ or objid.dtype.type is np.unicode_:
@@ -70,12 +70,13 @@ def unwrap_objid(objid):
     unwrap = np.recarray(objid.shape,
                          dtype=[('skyversion', 'i4'), ('rerun', 'i4'),
                                 ('run', 'i4'), ('camcol', 'i4'),
+                                ('firstfield', 'i4'),
                                 ('frame', 'i4'), ('id', 'i4')])
     unwrap.skyversion = np.bitwise_and(tempobjid >> 59, 2**4 - 1)
     unwrap.rerun = np.bitwise_and(tempobjid >> 48, 2**11 - 1)
     unwrap.run = np.bitwise_and(tempobjid >> 32, 2**16 - 1)
     unwrap.camcol = np.bitwise_and(tempobjid >> 29, 2**3 - 1)
-    # unwrap.firstfield = np.bitwise_and(tempobjid >> 28, 2**1 - 1)
+    unwrap.firstfield = np.bitwise_and(tempobjid >> 28, 2**1 - 1)
     unwrap.frame = np.bitwise_and(tempobjid >> 16, 2**12 - 1)
     unwrap.id = np.bitwise_and(tempobjid, 2**16 - 1)
     return unwrap

--- a/pydl/photoop/tests/test_photoop.py
+++ b/pydl/photoop/tests/test_photoop.py
@@ -24,6 +24,7 @@ class TestPhotoobj(object):
         assert objid.rerun == 301
         assert objid.run == 3704
         assert objid.camcol == 3
+        assert objid.firstfield == 0
         assert objid.frame == 91
         assert objid.id == 146
         objid = unwrap_objid(np.array(['1237661382772195474']))
@@ -31,7 +32,16 @@ class TestPhotoobj(object):
         assert objid.rerun == 301
         assert objid.run == 3704
         assert objid.camcol == 3
+        assert objid.firstfield == 0
         assert objid.frame == 91
         assert objid.id == 146
+        objid = unwrap_objid(np.array([587722984180548043]))
+        assert objid.skyversion == 1
+        assert objid.rerun == 40
+        assert objid.run == 752
+        assert objid.camcol == 5
+        assert objid.firstfield == 1
+        assert objid.frame == 618
+        assert objid.id == 459
         with raises(ValueError):
             objid = unwrap_objid(np.array([3.14159]))

--- a/pydl/pydlutils/cooling.py
+++ b/pydl/pydlutils/cooling.py
@@ -4,14 +4,6 @@
 """
 
 
-# Workaround: Numpy 1.14.x changes the way arrays are printed.
-import numpy as np
-try:
-    np.set_printoptions(legacy='1.13')
-except Exception:
-    pass
-
-
 def read_ds_cooling(fname, logT=None):
     """Read in the `Sutherland & Dopita (1993)
     <http://adsabs.harvard.edu/abs/1993ApJS...88..253S>`_ cooling function.

--- a/pydl/pydlutils/cooling.py
+++ b/pydl/pydlutils/cooling.py
@@ -4,6 +4,14 @@
 """
 
 
+# Workaround: Numpy 1.14.x changes the way arrays are printed.
+import numpy as np
+try:
+    np.set_printoptions(legacy='1.13')
+except Exception:
+    pass
+
+
 def read_ds_cooling(fname, logT=None):
     """Read in the `Sutherland & Dopita (1993)
     <http://adsabs.harvard.edu/abs/1993ApJS...88..253S>`_ cooling function.
@@ -35,9 +43,9 @@ def read_ds_cooling(fname, logT=None):
     --------
     >>> from pydl.pydlutils.cooling import read_ds_cooling
     >>> logT, loglambda = read_ds_cooling('m-15.cie')
-    >>> logT[0:5]
+    >>> logT[0:5] # doctest: +NORMALIZE_WHITESPACE
     array([ 4.  ,  4.05,  4.1 ,  4.15,  4.2 ])
-    >>> loglambda[0:5]
+    >>> loglambda[0:5] # doctest: +NORMALIZE_WHITESPACE
     array([-26.  , -24.66, -23.52, -22.62, -22.11])
     """
     from astropy.utils.data import get_pkg_data_contents

--- a/pydl/pydlutils/tests/test_sdss.py
+++ b/pydl/pydlutils/tests/test_sdss.py
@@ -199,6 +199,21 @@ class TestSDSS(object):
         # Exceptions
         #
         with raises(ValueError):
+            s = sdss_specobjid(np.array([4055, 4056]), 408, 55359, 'v5_7_0')
+        with raises(ValueError):
+            s = sdss_specobjid(4055, np.array([408, 409]), 55359, 'v5_7_0')
+        with raises(ValueError):
+            s = sdss_specobjid(4055, 408, np.array([55359, 55360]), 'v5_7_0')
+        with raises(ValueError):
+            s = sdss_specobjid(4055, 408, 55359,
+                               np.array(['v5_7_0', 'v5_7_2']))
+        with raises(ValueError):
+            s = sdss_specobjid(4055, 408, 55359, 'v5_7_0',
+                               line=np.array([137, 138]))
+        with raises(ValueError):
+            s = sdss_specobjid(4055, 408, 55359, 'v5_7_0',
+                               index=np.array([137, 138]))
+        with raises(ValueError):
             s = sdss_specobjid(4055, 408, 55359, 'v5_7_0', line=137,
                                index=137)
         with raises(ValueError):

--- a/pydl/pydlutils/tests/test_sdss.py
+++ b/pydl/pydlutils/tests/test_sdss.py
@@ -131,6 +131,8 @@ class TestSDSS(object):
         assert (np.array([1237661382772195474, 1237649770790322299],
                          dtype=np.int64) ==
                 sdss_objid(run, camcol, field, obj)).all()
+        assert (sdss_objid(752, 5, 618, 459, rerun=40,
+                           skyversion=1, firstfield=1) == 587722984180548043)
         #
         # Exceptions
         #
@@ -147,9 +149,15 @@ class TestSDSS(object):
         with raises(ValueError):
             objid = sdss_objid(3704, 3, 91, 146, skyversion=np.array([2, 3]))
         with raises(ValueError):
+            objid = sdss_objid(3704, 3, 91, 146, firstfield=np.array([0, 1]))
+        with raises(ValueError):
             objid = sdss_objid(3704, 3, 91, 146, skyversion=-2)
         with raises(ValueError):
             objid = sdss_objid(3704, 3, 91, 146, skyversion=16)
+        with raises(ValueError):
+            objid = sdss_objid(3704, 3, 91, 146, firstfield=-2)
+        with raises(ValueError):
+            objid = sdss_objid(3704, 3, 91, 146, firstfield=2)
         with raises(ValueError):
             objid = sdss_objid(3704, 3, 91, 146, rerun=-2)
         with raises(ValueError):

--- a/pydl/rebin.py
+++ b/pydl/rebin.py
@@ -44,9 +44,9 @@ def rebin(x, d, sample=False):
     --------
     >>> from numpy import arange, float
     >>> from pydl import rebin
-    >>> rebin(arange(10, dtype=float), (5,))
+    >>> rebin(arange(10, dtype=float), (5,)) # doctest: +NORMALIZE_WHITESPACE
     array([ 0.5,  2.5,  4.5,  6.5,  8.5])
-    >>> rebin(arange(5, dtype=float), (10,))
+    >>> rebin(arange(5, dtype=float), (10,)) # doctest: +NORMALIZE_WHITESPACE
     array([ 0. ,  0.5,  1. ,  1.5,  2. ,  2.5,  3. ,  3.5,  4. ,  4. ])
     """
     from numpy import floor, zeros


### PR DESCRIPTION
This PR fixes #37, by adding support for the `firstField` bit in DR7 and earlier ObjIDs.  In addition, a few test support features are added under the hood.