### PR TITLE
Fix FutureWarning due to nested sets in re in Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,8 @@ matrix:
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
         - os: linux
           env: NUMPY_VERSION=1.12
+        - os: linux
+          env: PYTHON_VERSION=3.7 NUMPY_VERSION=1.12
 
         # Try numpy pre-release
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,6 @@ matrix:
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
         - os: linux
           env: NUMPY_VERSION=1.12
-        - os: linux
-          env: PYTHON_VERSION=3.7 NUMPY_VERSION=1.12
 
         # Try numpy pre-release
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ env:
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
 matrix:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,8 @@ matrix:
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
         - os: linux
           env: NUMPY_VERSION=1.12
+        - os: linux
+          env: PYTHON_VERSION=3.7 NUMPY_VERSION=1.14
 
         # Try numpy pre-release
         - os: linux

--- a/docs/pydl/changes.rst
+++ b/docs/pydl/changes.rst
@@ -25,6 +25,7 @@ planned for the Summer or Fall of 2018.
 .. _`#41`: https://github.com/weaverba137/pydl/pull/41
 .. _`#40`: https://github.com/weaverba137/pydl/pull/40
 .. _`#37`: https://github.com/weaverba137/pydl/issues/37.
+.. _`#44`: https://github.com/weaverba137/pydl/pull/44
 
 0.6.0 (2017-09-19)
 ------------------

--- a/docs/pydl/changes.rst
+++ b/docs/pydl/changes.rst
@@ -19,6 +19,7 @@ planned for the Summer or Fall of 2018.
 * Add :mod:`astropy.units` support to :func:`~pydl.goddard.astro.airtovac`
   and :func:`~pydl.goddard.astro.vactoair` (PR `#41`_).
 * Change Exelis to Harris Geospatial (PR `#42`_).
+* Fix ``FutureWarning`` in ``re`` in Python 3.7 due to nested sets (PR `#44`_).
 
 .. _`#42`: https://github.com/weaverba137/pydl/pull/42
 .. _`#41`: https://github.com/weaverba137/pydl/pull/41

--- a/pydl/pydlutils/yanny.py
+++ b/pydl/pydlutils/yanny.py
@@ -444,7 +444,8 @@ class yanny(OrderedDict):
                 definition = defl
             else:
                 definition = defu
-            typere = re.compile(r'(\S+)\s+{0}([[<].*[]>]|);'.format(variable))
+            typere = re.compile(
+                r'(\S+)\s+{0}([\[<].*[\]>]|);'.format(variable))
             (typ, array) = typere.search(definition[0]).groups()
             var_type = typ + array.replace('<', '[').replace('>', ']')
             cache[variable] = var_type
@@ -499,7 +500,7 @@ class yanny(OrderedDict):
             result = cache[variable]
         except KeyError:
             typ = self.type(structure, variable)
-            character_array = re.compile(r'char[[<]\d*[]>][[<]\d*[]>]')
+            character_array = re.compile(r'char[\[<]\d*[\]>][\[<]\d*[\]>]')
             if ((character_array.search(typ) is not None) or
                     (typ.find('char') < 0 and (typ.find('[') >= 0 or
                                                typ.find('<') >= 0))):
@@ -1075,7 +1076,7 @@ class yanny(OrderedDict):
             for d in definitions:
                 d = d.replace(';', '')
                 (datatype, column) = re.split(r'\s+', d)
-                column = re.sub(r'[[<].*[]>]$', '', column)
+                column = re.sub(r'[\[<].*[\]>]$', '', column)
                 self._symbols[name.upper()].append(column)
                 self[name.upper()][column] = list()
         # Remove lines containing only comments


### PR DESCRIPTION
In Python 3.7, the `re` module raises a `FutureWarning` when using nested sets in a way that is not compatible with the syntax that will be used for them in the future. See [here](https://docs.python.org/dev/whatsnew/3.7.html#re) and [here](https://docs.python.org/3/library/re.html#regular-expression-syntax).

The `yanny` module was working fine with Python 3.7 but throwing a series of annoying `FutureWarning` messages. This seems to fix it.