### PR TITLE
Pin pytest 5

### DIFF
--- a/pydl/pydlutils/yanny.py
+++ b/pydl/pydlutils/yanny.py
@@ -1,4 +1,4 @@
-(str,)# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 """This module corresponds to the yanny directory in idlutils.
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,16 @@ requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
     setuptools_scm
+    tox-pypi-filter >= 0.12
 isolated_build = true
 
 [testenv]
+
+# The following option combined with the use of the tox-pypi-filter above allows
+# project-wide pinning of dependencies, e.g. if new versions of pytest do not
+# work correctly with pytest-astropy plugins. Most of the time the pinnings file
+# should be empty.
+pypi_filter = https://raw.githubusercontent.com/astropy/ci-helpers/master/pip_pinnings.txt
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS


### PR DESCRIPTION
This PR updates the tox.ini to use the same package pinning as astropy/ci-helpers.