### PR TITLE
Update set_maskbits to using the latest version of idlutils

### DIFF
--- a/pydl/pydlutils/sdss.py
+++ b/pydl/pydlutils/sdss.py
@@ -677,7 +677,7 @@ def sdss_sweep_circle(ra, dec, radius, stype='star', allobj=False):
         return None
 
 
-def set_maskbits(idlutils_version='v5_5_24', maskbits_file=None):
+def set_maskbits(idlutils_version='v5_5_33', maskbits_file=None):
     """Populate the maskbits cache.
 
     Parameters


### PR DESCRIPTION
This updates `set_maskbits` to use `v5_5_33` which will be the tagged version for DR17. We have added documentation on how to use pydl to deal with SDSS bitmasks and it would be nice to have the latest version by default.